### PR TITLE
Add status component with Font Awesome icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,13 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-bxVdyJqV0R7Yk8vLwawxjUY8ailqXF/w3vGN9VOGBev5nYeD1yfknhk+aoCA8DmF5asJ5AZt0fjOEtp5uWZL0w=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/StatusTag.tsx
+++ b/src/components/StatusTag.tsx
@@ -1,0 +1,41 @@
+import Tag from "./Tag";
+import { STATUS } from "../enums/status";
+import type { Status } from "../enums/status";
+
+const statusConfig: Record<Status, { label: string; icon: string; severity: "success" | "info" | "warning" }> = {
+  [STATUS.CONCLUIDO]: {
+    label: "Concluído",
+    icon: "fa-solid fa-check",
+    severity: "success",
+  },
+  [STATUS.FINALIZADO]: {
+    label: "Finalizado",
+    icon: "fa-solid fa-flag-checkered",
+    severity: "info",
+  },
+  [STATUS.EM_ANDAMENTO]: {
+    label: "Em andamento",
+    icon: "fa-solid fa-spinner fa-spin",
+    severity: "warning",
+  },
+};
+
+interface StatusTagProps {
+  status: Status;
+}
+
+export default function StatusTag({ status }: StatusTagProps) {
+  const { label, icon, severity } = statusConfig[status];
+  return (
+    <Tag
+      value={
+        <>
+          <i className={icon} style={{ marginRight: "0.25rem" }}></i>
+          {label}
+        </>
+      }
+      severity={severity}
+      rounded
+    />
+  );
+}

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import "./Tag.css";
 
 interface TagProps {
-  value: string;
+  value: ReactNode;
   severity?: "success" | "info" | "warning" | "danger"; // opcional
   rounded?: boolean; // opcional para deixar estilo "pill"
 }

--- a/src/enums/status.ts
+++ b/src/enums/status.ts
@@ -1,0 +1,7 @@
+export const STATUS = {
+  CONCLUIDO: "CONCLUIDO",
+  FINALIZADO: "FINALIZADO",
+  EM_ANDAMENTO: "EM_ANDAMENTO",
+} as const;
+
+export type Status = (typeof STATUS)[keyof typeof STATUS];

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -31,7 +31,7 @@
   flex-direction: column;
 }
 
-.guide span:not(.status) {
+.guide span:not(.tag) {
   font-size: 0.8rem;
 }
 
@@ -52,7 +52,3 @@
   align-items: center;
 }
 
-.status {
-  color: #28a745;
-  font-weight: bold;
-}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,6 +5,9 @@ import BeneficiaryCard from "../components/BeneficiaryCard";
 import Button from "../components/Button";
 import "./Dashboard.css";
 import Tag from "../components/Tag";
+import StatusTag from "../components/StatusTag";
+import { STATUS } from "../enums/status";
+import type { Status } from "../enums/status";
 
 interface Step {
   title: string;
@@ -19,7 +22,7 @@ interface Guide {
   date: string;
   doctor: string;
   hospital: string;
-  status: string;
+  status: Status;
   steps: Step[];
 }
 
@@ -31,7 +34,7 @@ const guides: Guide[] = [
     date: "28/09/2025",
     doctor: "Dr. Carlos Eduardo Silva",
     hospital: "Hospital Albert Einstein",
-    status: "Concluído",
+    status: STATUS.EM_ANDAMENTO,
     steps: [
       {
         title: "Finalizado",
@@ -69,7 +72,7 @@ const guides: Guide[] = [
     date: "28/09/2025",
     doctor: "Dr. Carlos Eduardo Silva",
     hospital: "Hospital Albert Einstein",
-    status: "Concluído",
+    status: STATUS.CONCLUIDO,
     steps: [
       {
         title: "Finalizado",
@@ -132,7 +135,7 @@ export default function Dashboard() {
               </span>
               <span>{g.hospital}</span>
               <div className="guide-actions">
-                <span className="status">{g.status}</span>
+                <StatusTag status={g.status} />
                 <Button variant="secondary" onClick={() => setSelected(g)}>
                   Ver detalhes
                 </Button>


### PR DESCRIPTION
## Summary
- create string-based STATUS enum and StatusTag component
- allow Tag to render icons and include Font Awesome via CDN
- use StatusTag in dashboard and refine dashboard styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf3b440f8483278b5efef728d40722