### PR TITLE
feat: add mobile header with user menu

### DIFF
--- a/src/base/BaseLayout.tsx
+++ b/src/base/BaseLayout.tsx
@@ -1,4 +1,5 @@
 import Header from "../components/Header";
+import MobileHeader from "../components/MobileHeader";
 import BeneficiaryCard from "../components/BeneficiaryCard";
 import "./BaseLayout.css";
 import type { ReactNode } from "react";
@@ -15,6 +16,11 @@ export default function BaseLayout({ children }: BaseLayoutProps) {
         cardNumber="123456789"
         operator="FESUL"
         className="layout-header"
+      />
+      <MobileHeader
+        userName="Ana Paula"
+        cardNumber="123456789"
+        operator="FESUL"
       />
       <div className="dashboard-content">
         <BeneficiaryCard

--- a/src/components/MobileHeader.css
+++ b/src/components/MobileHeader.css
@@ -1,0 +1,84 @@
+.mobile-header {
+  display: none;
+  background-color: #1e5d96;
+  color: #fff;
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  margin-bottom: 2rem;
+  position: relative;
+}
+
+.mobile-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.menu-button {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+}
+
+.mobile-user-data {
+  display: flex;
+  margin-top: 1rem;
+}
+
+.avatar {
+  font-size: 2rem;
+  margin-right: 0.5rem;
+}
+
+.mobile-user-text {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+}
+
+.mobile-menu {
+  position: absolute;
+  inset: 0;
+  background-color: #1e5d96;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 12px;
+}
+
+.mobile-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 2rem;
+}
+
+.mobile-menu li {
+  text-align: center;
+}
+
+.mobile-menu button {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.close-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+}
+
+@media (max-width: 1000px) {
+  .mobile-header {
+    display: block;
+  }
+}

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import "./MobileHeader.css";
+
+interface MobileHeaderProps extends React.HTMLAttributes<HTMLElement> {
+  userName: string;
+  cardNumber: string;
+  operator: string;
+}
+
+export default function MobileHeader({
+  userName,
+  cardNumber,
+  operator,
+  className = "",
+  ...rest
+}: MobileHeaderProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className={`mobile-header ${className}`} {...rest}>
+      <div className="mobile-header-top">
+        <h2>Portal do Beneficiário</h2>
+        <button
+          className="menu-button"
+          onClick={() => setOpen(true)}
+          aria-label="Abrir menu"
+        >
+          ☰
+        </button>
+      </div>
+
+      <div className="mobile-user-data">
+        <div className="avatar">👤</div>
+        <div className="mobile-user-text">
+          <span className="user-greeting">Olá, {userName}!</span>
+          <span>N° da carteirinha: {cardNumber}</span>
+          <span>Operadora: {operator}</span>
+        </div>
+      </div>
+
+      {open && (
+        <nav className="mobile-menu">
+          <button
+            className="close-button"
+            onClick={() => setOpen(false)}
+            aria-label="Fechar menu"
+          >
+            ✕
+          </button>
+          <ul>
+            <li>
+              <button>Consultar Guias</button>
+            </li>
+            <li>
+              <button>Meus Dados</button>
+            </li>
+            <li>
+              <button>Sair</button>
+            </li>
+          </ul>
+        </nav>
+      )}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add mobile-focused header component with user info and toggleable menu
- render mobile header in base layout for small screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf7bd3a8448327a6a8bfe8d23f3775