### PR TITLE
Toggle mobile menu between dashboard and profile

### DIFF
--- a/src/base/BaseLayout.css
+++ b/src/base/BaseLayout.css
@@ -37,3 +37,21 @@
     display: none;
   }
 }
+
+.mobile-beneficiary {
+  display: none;
+}
+
+.hidden-on-mobile {
+  display: block;
+}
+
+@media (max-width: 1000px) {
+  .mobile-beneficiary {
+    display: block;
+  }
+
+  .hidden-on-mobile {
+    display: none;
+  }
+}

--- a/src/base/BaseLayout.tsx
+++ b/src/base/BaseLayout.tsx
@@ -12,6 +12,15 @@ import MobileHeader from "../components/MobileHeader";
 
 export default function BaseLayout({ children }: BaseLayoutProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [mobileView, setMobileView] = useState<"dashboard" | "profile">("dashboard");
+
+  const beneficiaryData = {
+    name: "Maria Oliveira Santos",
+    birthDate: "01/08/1995",
+    phone: "(99) 99999-0450",
+    email: "teste@email.com",
+  };
+
   return (
     <div className="default">
       <Header
@@ -26,17 +35,34 @@ export default function BaseLayout({ children }: BaseLayoutProps) {
         operator="FESUL"
         open={isMobileMenuOpen}
         onToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+        onSelectDashboard={() => {
+          setMobileView("dashboard");
+          setIsMobileMenuOpen(false);
+        }}
+        onSelectProfile={() => {
+          setMobileView("profile");
+          setIsMobileMenuOpen(false);
+        }}
       />
       <div className="dashboard-content">
         <BeneficiaryCard
-          name="Maria Oliveira Santos"
-          birthDate="01/08/1995"
-          phone="(99) 99999-0450"
-          email="teste@email.com"
+          {...beneficiaryData}
           className="layout-beneficiary"
           isMobileMenuOpen={isMobileMenuOpen}
         />
-        <main className="main-content">{children}</main>
+        {mobileView === "profile" && (
+          <BeneficiaryCard
+            {...beneficiaryData}
+            className="mobile-beneficiary"
+          />
+        )}
+        <main
+          className={`main-content ${
+            mobileView === "profile" ? "hidden-on-mobile" : ""
+          }`}
+        >
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -6,6 +6,8 @@ export interface MobileHeaderProps {
   operator: string;
   open: boolean;
   onToggle: () => void;
+  onSelectDashboard: () => void;
+  onSelectProfile: () => void;
 }
 
 export default function MobileHeader({
@@ -14,6 +16,8 @@ export default function MobileHeader({
   operator,
   open,
   onToggle,
+  onSelectDashboard,
+  onSelectProfile,
 }: MobileHeaderProps) {
   return (
     <header className="mobile-header">
@@ -63,7 +67,7 @@ export default function MobileHeader({
             }}
           >
             <img src="../../public/svg/guia-medica.svg" alt="" />
-            <button>Consultar Guias</button>
+            <button onClick={onSelectDashboard}>Consultar Guias</button>
           </li>
           <li
             style={{
@@ -75,7 +79,7 @@ export default function MobileHeader({
           >
             <img src="../../public/svg/paciente.svg" alt="" />
 
-            <button>Meus Dados</button>
+            <button onClick={onSelectProfile}>Meus Dados</button>
           </li>
           <li
             style={{


### PR DESCRIPTION
## Summary
- add profile and dashboard selection handlers to the mobile header
- render BeneficiaryCard instead of dashboard when profile is chosen on mobile
- introduce mobile styles for conditional display

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c033b085c8832799be232c1f68bdbd