### PR TITLE
refactor: centralize formatting helpers

### DIFF
--- a/src/components/BeneficiaryCard.tsx
+++ b/src/components/BeneficiaryCard.tsx
@@ -1,6 +1,7 @@
 import "./BeneficiaryCard.css";
 import Button from "./Button";
 import { useState } from "react";
+import { formatCPF, formatPhone } from "../utils/formatters";
 
 interface BeneficiaryCardProps extends React.HTMLAttributes<HTMLElement> {
   cpf: string;
@@ -51,14 +52,6 @@ export default function BeneficiaryCard({
     }
 
     setFormData((prev) => ({ ...prev, [field]: value }));
-  };
-  const formatCPF = (value: string) => {
-    if (!value) return "";
-    return value
-      .replace(/\D/g, "") // só números
-      .replace(/(\d{3})(\d)/, "$1.$2")
-      .replace(/(\d{3})(\d)/, "$1.$2")
-      .replace(/(\d{3})(\d{1,2})$/, "$1-$2");
   };
   const addPhone = () =>
     setFormData((prev) => ({ ...prev, phones: [...prev.phones, ""] }));
@@ -122,7 +115,7 @@ export default function BeneficiaryCard({
                 placeholder="(11) 99999-9999"
               />
             ) : (
-              <p key={`phone-${idx}`}>{phone}</p>
+              <p key={`phone-${idx}`}>{formatPhone(phone)}</p>
             )
           )}
           {isEditing && (

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,53 @@
+const NON_DIGIT_REGEX = /\D+/g;
+
+const normalizeDigits = (value: string | null | undefined) =>
+  (value ?? "").replace(NON_DIGIT_REGEX, "");
+
+/**
+ * Formata um CPF para o padrão 000.000.000-00.
+ * Aceita valores já formatados ou somente com dígitos.
+ */
+export const formatCPF = (value: string | null | undefined): string => {
+  const digits = normalizeDigits(value).slice(0, 11);
+
+  if (!digits) {
+    return "";
+  }
+
+  return digits
+    .replace(/(\d{3})(\d)/, "$1.$2")
+    .replace(/(\d{3})(\d)/, "$1.$2")
+    .replace(/(\d{3})(\d{1,2})$/, "$1-$2");
+};
+
+/**
+ * Formata telefones nacionais considerando DDD e números de 8 ou 9 dígitos.
+ */
+export const formatPhone = (value: string | null | undefined): string => {
+  const digits = normalizeDigits(value).slice(0, 11);
+
+  if (!digits) {
+    return "";
+  }
+
+  if (digits.length <= 2) {
+    return `(${digits}`;
+  }
+
+  const ddd = digits.slice(0, 2);
+  const remaining = digits.slice(2);
+
+  if (remaining.length <= 4) {
+    return `(${ddd}) ${remaining}`;
+  }
+
+  const middle = remaining.length === 8
+    ? remaining.slice(0, 4)
+    : remaining.slice(0, remaining.length - 4);
+  const suffix = remaining.slice(remaining.length - 4);
+
+  return `(${ddd}) ${middle}-${suffix}`;
+};
+
+export const digitsOnly = (value: string | null | undefined): string =>
+  normalizeDigits(value);


### PR DESCRIPTION
## Summary
- extract CPF and phone formatting helpers into a reusable `src/utils/formatters` module
- update the beneficiary card to consume the shared formatters for CPF and phone presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc5f2b00408327820315ebe2da3780