### PR TITLE
Fix timeline markers and mobile back action

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -12,10 +12,12 @@ export default function Button({
   children,
   variant = "primary",
   className = "",
+  type = "button",
   ...props
 }: ButtonProps) {
   return (
     <button
+      type={type}
       className={`btn btn-${variant} ${className}`.trim()}
       {...props}
     >

--- a/src/components/DetailsModal.css
+++ b/src/components/DetailsModal.css
@@ -117,32 +117,46 @@
 
 /* cada item controla sua própria linha */
 .timeline-item {
-  position: relative;
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
   text-align: justify;
   padding: 0.5rem 0 1rem 0;
 }
 
-.timeline-item .dot {
-  position: relative;
-  z-index: 1;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  margin-top: 4px;
-  margin-right: 1rem;
+.timeline-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  margin-right: 0.5rem;
+  flex-shrink: 0;
 }
 
-/* linha abaixo do dot até o fim do item */
-.timeline-item::after {
-  content: "";
-  position: absolute;
-  top: 15px; /* começa abaixo do dot */
-  left: 5px; /* centralizado com o dot */
+.timeline-dot {
+  display: block;
+}
+
+.timeline-connector {
+  flex: 1 1 auto;
   width: 1px;
-  height: 100%;
   background: rgb(212, 212, 212);
+}
+
+.timeline-content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.timeline-content-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.timeline-item:last-child .timeline-connector {
+  display: none;
 }
 
 .timeline-item strong {

--- a/src/components/DetailsModal.tsx
+++ b/src/components/DetailsModal.tsx
@@ -24,6 +24,28 @@ interface DetailsModalProps {
 }
 
 export default function DetailsModal({ guide, onClose }: DetailsModalProps) {
+  const firstPendingIndex = guide.steps.findIndex(
+    (step) => !step.date?.trim(),
+  );
+
+  const getDotVariant = (index: number) => {
+    if (firstPendingIndex === -1 || index < firstPendingIndex) {
+      return "completed";
+    }
+
+    if (index === firstPendingIndex) {
+      return "current";
+    }
+
+    return "upcoming";
+  };
+
+  const dotConfig = {
+    completed: { src: "/images/dot1.png", size: 32 },
+    current: { src: "/images/dot2.png", size: 24 },
+    upcoming: { src: "/images/dot3.png", size: 24 },
+  } as const;
+
   return (
     <div className="details-view">
       <div className="header-top">
@@ -47,28 +69,35 @@ export default function DetailsModal({ guide, onClose }: DetailsModalProps) {
 
       <div className="timeline">
         <h4 style={{ fontWeight: "500" }}>Histórico</h4>
-        {guide.steps.map((s) => (
-          <div key={s.title} className="timeline-item">
-            <span className="dot" />
-            <div
-              style={{
-                width: "100%",
-                display: "flex",
-                flexDirection: "column",
-                gap: "0.2rem",
-              }}
-            >
-              <div style={{ display: "flex", justifyContent: "space-between" }}>
-                <h4>{s.title}</h4>
-                {s.date && <Tag severity="neutro" value={s.date} />}
+        {guide.steps.map((s, index) => {
+          const variant = getDotVariant(index);
+          const isLast = index === guide.steps.length - 1;
+          const { src, size } = dotConfig[variant];
+
+          return (
+            <div key={s.title} className="timeline-item">
+              <div className="timeline-marker">
+                <img
+                  className="timeline-dot"
+                  src={src}
+                  alt=""
+                  style={{ width: size, height: size }}
+                />
+                {!isLast && <span className="timeline-connector" />}
               </div>
-              <div className="info-timeline">
-                <span className="info-span">{s.description}</span>
-                <span className="info-span card-info">{s.info}</span>
+              <div className="timeline-content">
+                <div className="timeline-content-header">
+                  <h4>{s.title}</h4>
+                  {s.date && <Tag severity="neutro" value={s.date} />}
+                </div>
+                <div className="info-timeline">
+                  <span className="info-span">{s.description}</span>
+                  <span className="info-span card-info">{s.info}</span>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- default all custom buttons to type="button" so the back action works correctly on mobile
- render timeline markers with the provided dot assets and update the connector layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15bf44b30832790e327cb960d9410