### PR TITLE
Implement authenticated login flow

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.seu-dominio.com

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import BaseLayout from "./base/BaseLayout";
+import { getStoredToken } from "./utils/auth";
 
 export default function App() {
-  const [loggedIn, setLoggedIn] = useState(false);
+  const [loggedIn, setLoggedIn] = useState(() => Boolean(getStoredToken()));
+
+  useEffect(() => {
+    setLoggedIn(Boolean(getStoredToken()));
+  }, []);
 
   if (!loggedIn) {
     return <Login onLogin={() => setLoggedIn(true)} />;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,13 +1,41 @@
+import { FormEvent, useState } from "react";
 import "./Login.css";
 import Button from "../components/Button/Button";
-import { useState } from "react";
+import { authenticate } from "../utils/api";
+import { storeToken } from "../utils/auth";
 
 interface LoginProps {
   onLogin: () => void;
 }
 
 export default function Login({ onLogin }: LoginProps) {
-  const [cpfOrDate] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage("");
+
+    if (!email || !password) {
+      setErrorMessage("Informe o e-mail e a senha para continuar.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const token = await authenticate(email, password);
+      storeToken(token);
+      onLogin();
+    } catch {
+      setErrorMessage(
+        "Não foi possível realizar login. Verifique suas credenciais.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <div style={{ display: "flex", justifyContent: "space-between" }}>
@@ -22,27 +50,49 @@ export default function Login({ onLogin }: LoginProps) {
               Acesse e acompanhe o status das guias solicitadas para o seu
               <strong> plano de saúde</strong>.
             </span>
-            <label className="label-input">E-mail</label>
-            <input
-              style={{ marginBottom: "1.5rem" }}
-              className="login-input"
-              value={cpfOrDate}
-              placeholder="email@mail.com"
-            />
+            <form onSubmit={handleSubmit}>
+              <label className="label-input">E-mail</label>
+              <input
+                style={{ marginBottom: "1.5rem" }}
+                className="login-input"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="email@mail.com"
+                type="email"
+                autoComplete="username"
+              />
 
-            <label className="label-input">Senha</label>
-            <input type="password" placeholder="Digite sua senha" />
+              <label className="label-input">Senha</label>
+              <input
+                type="password"
+                placeholder="Digite sua senha"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="current-password"
+              />
 
-            <div className="login-options">
-              <label className="remember">
-                <input type="checkbox" /> Lembrar senha
-              </label>
-              <a href="#">Esqueci minha senha</a>
-            </div>
+              <div className="login-options">
+                <label className="remember">
+                  <input type="checkbox" /> Lembrar senha
+                </label>
+                <a href="#">Esqueci minha senha</a>
+              </div>
 
-            <Button variant="primary" onClick={onLogin}>
-              Entrar
-            </Button>
+              {errorMessage ? (
+                <p style={{ color: "#dc3545", marginTop: "1rem" }}>
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              <Button
+                variant="primary"
+                type="submit"
+                disabled={isSubmitting}
+                style={{ marginTop: "1.5rem" }}
+              >
+                {isSubmitting ? "Entrando..." : "Entrar"}
+              </Button>
+            </form>
 
             <div className="signup">
               Ainda não tem conta? <a href="#">Cadastre-se</a>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,45 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+function getEndpoint(path: string) {
+  if (!API_BASE_URL) {
+    throw new Error("A URL base da API não foi configurada.");
+  }
+
+  return new URL(path, API_BASE_URL).toString();
+}
+
+interface AuthResponse {
+  access_token?: string;
+  token?: string;
+  [key: string]: unknown;
+}
+
+export async function authenticate(
+  username: string,
+  password: string,
+): Promise<string> {
+  const response = await fetch(getEndpoint("/auth"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      username,
+      password,
+    }).toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error("Falha ao autenticar");
+  }
+
+  const data = (await response.json()) as AuthResponse;
+  const token = data.access_token ?? data.token;
+
+  if (!token) {
+    throw new Error("Token não encontrado na resposta");
+  }
+
+  return token;
+}
+

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,30 @@
+const TOKEN_STORAGE_KEY = "authToken";
+
+export function getStoredToken(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.localStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
+export function storeToken(token: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(TOKEN_STORAGE_KEY, token);
+}
+
+export function clearStoredToken() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+}
+
+export function hasStoredToken() {
+  return Boolean(getStoredToken());
+}
+


### PR DESCRIPTION
## Summary
- check for stored authentication token before showing protected areas
- add API helper and login form submission to authenticate users against backend
- configure environment variables to point to local and production API URLs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d435e51b808327ba8c080b11486d2f