### PR TITLE
Integrate login with new authentication endpoints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,25 +3,53 @@ import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import BaseLayout from "./base/BaseLayout";
 import { clearStoredToken, getStoredToken } from "./utils/auth";
+import { fetchCurrentUser } from "./utils/api";
+import type { UserProfile } from "./types/user";
 
 export default function App() {
-  const [loggedIn, setLoggedIn] = useState(() => Boolean(getStoredToken()));
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
 
   useEffect(() => {
-    setLoggedIn(Boolean(getStoredToken()));
+    const token = getStoredToken();
+
+    if (!token) {
+      setIsCheckingAuth(false);
+      return;
+    }
+
+    fetchCurrentUser(token)
+      .then((currentUser) => {
+        setUser(currentUser);
+      })
+      .catch(() => {
+        clearStoredToken();
+        setUser(null);
+      })
+      .finally(() => {
+        setIsCheckingAuth(false);
+      });
   }, []);
+
+  const handleLogin = (currentUser: UserProfile) => {
+    setUser(currentUser);
+  };
 
   const handleLogout = () => {
     clearStoredToken();
-    setLoggedIn(false);
+    setUser(null);
   };
 
-  if (!loggedIn) {
-    return <Login onLogin={() => setLoggedIn(true)} />;
+  if (isCheckingAuth) {
+    return null;
+  }
+
+  if (!user) {
+    return <Login onLogin={handleLogin} />;
   }
 
   return (
-    <BaseLayout onLogout={handleLogout}>
+    <BaseLayout user={user} onLogout={handleLogout}>
       <Dashboard />
     </BaseLayout>
   );

--- a/src/base/BaseLayout.tsx
+++ b/src/base/BaseLayout.tsx
@@ -1,37 +1,47 @@
 import Header from "../components/Header/Header";
 import "./BaseLayout.css";
-import type { ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
+import MobileHeader from "../components/MobileHeader/MobileHeader";
+import BeneficiaryCard from "../components/BeneficiaryCard/BeneficiaryCard";
+import type { UserProfile } from "../types/user";
 
 interface BaseLayoutProps {
   children: ReactNode;
   onLogout: () => void;
+  user: UserProfile;
 }
 
-import { useState } from "react";
-import MobileHeader from "../components/MobileHeader/MobileHeader";
-import BeneficiaryCard from "../components/BeneficiaryCard/BeneficiaryCard";
+function formatPhones(phones?: string[]) {
+  if (!phones || phones.length === 0) {
+    return [];
+  }
 
-export default function BaseLayout({ children, onLogout }: BaseLayoutProps) {
+  return phones.filter((phone) => Boolean(phone));
+}
+
+export default function BaseLayout({ children, onLogout, user }: BaseLayoutProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [mobileView, setMobileView] = useState<"dashboard" | "profile">(
-    "dashboard"
+    "dashboard",
   );
 
-  const beneficiaryData = {
-    name: "Maria Oliveira Santos",
-    birthDate: "01/08/1995",
-    cpf: "609.291.063-26",
-    phones: ["(99) 99999-0450"],
-    emails: ["teste@email.com"],
-  };
+  const beneficiaryData = useMemo(() => {
+    return {
+      name: user.name || "",
+      birthDate: user.birthDate ?? "",
+      cpf: user.cpf ?? "",
+      phones: formatPhones(user.phones),
+      emails: user.emails && user.emails.length > 0 ? user.emails : [user.email],
+    };
+  }, [user]);
 
   return (
     <div className="default">
       <Header onLogout={onLogout} />
       <MobileHeader
-        userName="Ana Paula"
-        cardNumber="123456789"
-        operator="FESUL"
+        userName={user.name}
+        cardNumber={user.cardNumber ?? ""}
+        operator={user.operator ?? ""}
         open={isMobileMenuOpen}
         onToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
         onSelectDashboard={() => {

--- a/src/components/MobileHeader/MobileHeader.css
+++ b/src/components/MobileHeader/MobileHeader.css
@@ -13,6 +13,14 @@
   position: relative;
 }
 
+.mobile-user-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+}
+
 .mobile-header-top .titulo {
   margin: 0;
   font-size: 1rem;

--- a/src/components/MobileHeader/MobileHeader.tsx
+++ b/src/components/MobileHeader/MobileHeader.tsx
@@ -12,6 +12,9 @@ export interface MobileHeaderProps {
 }
 
 export default function MobileHeader({
+  userName,
+  cardNumber,
+  operator,
   open,
   onToggle,
   onSelectDashboard,
@@ -31,6 +34,14 @@ export default function MobileHeader({
           {open ? "✕" : "☰"}
         </button>
       </div>
+
+      {!open && (
+        <div className="mobile-user-info">
+          <p>{userName}</p>
+          {cardNumber && <span>Cartão: {cardNumber}</span>}
+          {operator && <span>Operadora: {operator}</span>}
+        </div>
+      )}
 
       <nav className={`mobile-menu ${open ? "open" : ""}`}>
         <ul>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,13 @@
-import { FormEvent, useState } from "react";
+import { useState } from "react";
+import type { FormEvent } from "react";
 import "./Login.css";
 import Button from "../components/Button/Button";
-import { authenticate } from "../utils/api";
+import { authenticate, fetchCurrentUser } from "../utils/api";
 import { storeToken } from "../utils/auth";
+import type { UserProfile } from "../types/user";
 
 interface LoginProps {
-  onLogin: () => void;
+  onLogin: (user: UserProfile) => void;
 }
 
 export default function Login({ onLogin }: LoginProps) {
@@ -26,9 +28,11 @@ export default function Login({ onLogin }: LoginProps) {
     try {
       setIsSubmitting(true);
       const token = await authenticate(email, password);
+      const user = await fetchCurrentUser(token);
       storeToken(token);
-      onLogin();
-    } catch {
+      onLogin(user);
+    } catch (error) {
+      console.error(error);
       setErrorMessage(
         "Não foi possível realizar login. Verifique suas credenciais.",
       );

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,27 @@
+export interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  cpf?: string;
+  birthDate?: string;
+  phones?: string[];
+  emails?: string[];
+  cardNumber?: string;
+  operator?: string;
+}
+
+export type CurrentUserResponse = {
+  id?: string | number;
+  name?: string;
+  email?: string;
+  cpf?: string;
+  birthDate?: string;
+  birth_date?: string;
+  date_of_birth?: string;
+  phones?: unknown;
+  emails?: unknown;
+  cardNumber?: string;
+  card_number?: string;
+  operator?: string;
+  [key: string]: unknown;
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,3 +1,5 @@
+import type { CurrentUserResponse, UserProfile } from "../types/user";
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 function getEndpoint(path: string) {
@@ -14,19 +16,46 @@ interface AuthResponse {
   [key: string]: unknown;
 }
 
-export async function authenticate(
-  username: string,
-  password: string,
-): Promise<string> {
-  const response = await fetch(getEndpoint("/auth"), {
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item));
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    return [value];
+  }
+
+  return undefined;
+}
+
+function normalizeBirthDate(response: CurrentUserResponse): string | undefined {
+  const { birthDate, birth_date, date_of_birth } = response;
+  const rawDate = birthDate ?? birth_date ?? date_of_birth;
+
+  if (!rawDate) {
+    return undefined;
+  }
+
+  const isoDateMatch = /^\d{4}-\d{2}-\d{2}/.test(rawDate);
+
+  if (!isoDateMatch) {
+    return rawDate;
+  }
+
+  const [year, month, day] = rawDate.split("T")[0].split("-");
+  return `${day}/${month}/${year}`;
+}
+
+export async function authenticate(email: string, password: string): Promise<string> {
+  const response = await fetch(getEndpoint("/auth/login"), {
     method: "POST",
     headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
+      "Content-Type": "application/json",
     },
-    body: new URLSearchParams({
-      username,
+    body: JSON.stringify({
+      email,
       password,
-    }).toString(),
+    }),
   });
 
   if (!response.ok) {
@@ -43,3 +72,29 @@ export async function authenticate(
   return token;
 }
 
+export async function fetchCurrentUser(token: string): Promise<UserProfile> {
+  const response = await fetch(getEndpoint("/users/current"), {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Falha ao buscar usuário logado");
+  }
+
+  const data = (await response.json()) as CurrentUserResponse;
+
+  return {
+    id: String(data.id ?? ""),
+    name: data.name ?? "",
+    email: data.email ?? "",
+    cpf: data.cpf,
+    birthDate: normalizeBirthDate(data),
+    phones: normalizeStringArray(data.phones),
+    emails: normalizeStringArray(data.emails) ?? normalizeStringArray(data.email),
+    cardNumber: data.cardNumber ?? data.card_number,
+    operator: data.operator,
+  };
+}


### PR DESCRIPTION
## Summary
- update the API client to authenticate with /auth/login and fetch the current user profile
- load the authenticated user in the app state to drive the dashboard layout and beneficiary card data
- surface logged-in user details in the mobile header and adjust styles for the new information

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6ca64e00c8327bcef71c72e9cae2a